### PR TITLE
Add price item management to budget calculations

### DIFF
--- a/api_data.php
+++ b/api_data.php
@@ -18,6 +18,9 @@ switch ($dataType) {
     case 'vendors':
         $data = get_vendors();
         break;
+    case 'price_items':
+        $data = get_price_items();
+        break;
     case 'tables':
         $data = get_tables();
         // Dodatkowa logika do uzupełnienia nazw gości w miejscach

--- a/css/style.css
+++ b/css/style.css
@@ -77,6 +77,12 @@ button.secondary:hover { background-color: #888; }
 #vendorList li { display: flex; flex-wrap: wrap; justify-content: space-between; align-items: center; padding: 10px; border-bottom: 1px solid #eee; gap: 10px; }
 .vendor-details { display: flex; flex-direction: column; }
 .vendor-details .date-info { font-size: 0.8em; color: #666; }
+#priceItemsList { list-style: none; margin-top: 20px; padding: 0; }
+#priceItemsList li.empty { font-style: italic; color: #666; }
+.price-item-row { display: flex; flex-wrap: wrap; justify-content: space-between; align-items: center; gap: 10px; padding: 10px; border-bottom: 1px solid #eee; }
+.price-item-details { display: flex; flex-direction: column; gap: 4px; }
+.price-item-meta { font-size: 0.9em; color: #666; }
+.price-item-actions { display: flex; gap: 8px; flex-shrink: 0; }
 .budget-summary p { font-size: 1.1em; margin: 5px 0; }
 .budget-summary strong { color: var(--primary-color); }
 

--- a/index.php
+++ b/index.php
@@ -82,7 +82,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $paid_full = isset($_POST['vendorPaidFull']) ? 1 : 0;
                 $payment_date = $_POST['vendorPaymentDate'] ?? null;
                 $vendor_name = $_POST['vendorName'];
-                
+
                 // Funkcja add_vendor zwraca teraz ID nowego dostawcy lub false
                 $new_vendor_id = add_vendor($vendor_name, (float)$_POST['vendorCost'], (float)$_POST['vendorDeposit'], $paid_full, $payment_date);
 
@@ -101,6 +101,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 } else {
                     $response = ['success' => false, 'message' => 'Nie udało się dodać kosztu.'];
                 }
+                break;
+            case 'add_price_item':
+                add_price_item(
+                    $_POST['priceItemName'] ?? '',
+                    $_POST['priceItemAmount'] ?? '0',
+                    $_POST['priceItemScope'] ?? 'all'
+                );
+                $response = ['success' => true, 'message' => 'Pozycja cenowa dodana.'];
+                break;
+            case 'update_price_item':
+                update_price_item(
+                    (int)($_POST['priceItemId'] ?? 0),
+                    $_POST['priceItemName'] ?? '',
+                    $_POST['priceItemAmount'] ?? '0',
+                    $_POST['priceItemScope'] ?? 'all'
+                );
+                $response = ['success' => true, 'message' => 'Pozycja cenowa zaktualizowana.'];
+                break;
+            case 'delete_price_item':
+                delete_price_item((int)($_POST['priceItemId'] ?? 0));
+                $response = ['success' => true, 'message' => 'Pozycja cenowa usunięta.'];
                 break;
 
             case 'edit_vendor':
@@ -368,11 +389,26 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     </form>
                     <ul id="vendorList"></ul>
                 </div>
+                <div class="additional-price-items">
+                    <h3>Dodatkowe pozycje cenowe</h3>
+                    <form class="price-item-form ajax-form">
+                        <input type="hidden" name="action" value="add_price_item">
+                        <input type="text" id="priceItemName" name="priceItemName" placeholder="Nazwa pozycji" required>
+                        <input type="number" id="priceItemAmount" name="priceItemAmount" placeholder="Kwota" min="0" step="0.01" required>
+                        <select id="priceItemScope" name="priceItemScope">
+                            <option value="all">Wszyscy goście</option>
+                            <option value="adults">Tylko dorośli</option>
+                        </select>
+                        <button type="submit">Dodaj pozycję</button>
+                    </form>
+                    <ul id="priceItemsList"></ul>
+                </div>
                 <div class="budget-summary">
                     <h3>Podsumowanie Kosztów</h3>
                     <p>Koszt "talerzyka" dla gości: <span id="guestMealCost">0.00</span> PLN</p>
                     <p>Koszt noclegów dla gości: <span id="guestAccommCost">0.00</span> PLN</p>
                     <p>Koszt usługodawców: <span id="vendorTotalCost">0.00</span> PLN</p><hr>
+                    <p>Dodatkowe koszty na osoby: <span id="additionalPerGuestCost">0.00</span> PLN</p>
                     <p><strong>Całkowity koszt wesela: <span id="totalWeddingCost">0.00</span> PLN</strong></p>
                     <p><strong>Suma wpłat (zaliczki + opłacone): <span id="totalPaid">0.00</span> PLN</strong></p>
                     <p><strong>Pozostało do zapłaty: <span id="totalRemaining">0.00</span> PLN</strong></p>

--- a/index.php
+++ b/index.php
@@ -11,6 +11,8 @@ if ($settings_from_db) {
     }
 }
 
+$price_items_from_db = get_price_items();
+
 // --- Obsługa żądań POST (teraz wszystkie zwracają JSON) ---
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     header('Content-Type: application/json');
@@ -401,7 +403,33 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         </select>
                         <button type="submit">Dodaj pozycję</button>
                     </form>
-                    <ul id="priceItemsList"></ul>
+                    <ul id="priceItemsList">
+                        <?php if (!empty($price_items_from_db)): ?>
+                            <?php foreach ($price_items_from_db as $price_item): ?>
+                                <?php
+                                    $item_id = (int)($price_item['id'] ?? 0);
+                                    $item_label = $price_item['label'] ?? '';
+                                    $item_amount = isset($price_item['amount']) ? (float)$price_item['amount'] : 0.0;
+                                    $item_scope = $price_item['scope'] ?? 'all';
+                                    $scope_label = $item_scope === 'adults' ? 'tylko dorośli' : 'wszyscy goście';
+                                ?>
+                                <li class="price-item-row" data-item-id="<?php echo $item_id; ?>">
+                                    <div class="price-item-details">
+                                        <strong><?php echo htmlspecialchars($item_label, ENT_QUOTES, 'UTF-8'); ?></strong>
+                                        <span class="price-item-meta">
+                                            <?php echo number_format($item_amount, 2, ',', ' '); ?> PLN · <?php echo htmlspecialchars($scope_label, ENT_QUOTES, 'UTF-8'); ?>
+                                        </span>
+                                    </div>
+                                    <div class="price-item-actions">
+                                        <button type="button" onclick="openPriceItemEdit(<?php echo $item_id; ?>)">Edytuj</button>
+                                        <button type="button" class="secondary" onclick="confirmRemovePriceItem(<?php echo $item_id; ?>, <?php echo json_encode($item_label, JSON_HEX_APOS | JSON_HEX_QUOT); ?>)">Usuń</button>
+                                    </div>
+                                </li>
+                            <?php endforeach; ?>
+                        <?php else: ?>
+                            <li class="empty">Brak dodatkowych pozycji.</li>
+                        <?php endif; ?>
+                    </ul>
                 </div>
                 <div class="budget-summary">
                     <h3>Podsumowanie Kosztów</h3>

--- a/js/script.js
+++ b/js/script.js
@@ -352,12 +352,22 @@ function renderPriceItems() {
 
     priceItems.forEach(item => {
         const li = document.createElement('li');
+        li.className = 'price-item-row';
         li.dataset.itemId = item.id;
 
         const details = document.createElement('div');
         details.className = 'price-item-details';
+
+        const nameEl = document.createElement('strong');
+        nameEl.textContent = item.label;
+
+        const metaEl = document.createElement('span');
+        metaEl.className = 'price-item-meta';
         const amount = parseFloat(item.amount) || 0;
-        details.innerHTML = `<strong>${item.label}</strong> - ${amount.toFixed(2)} PLN (${scopeLabels[item.scope] || item.scope})`;
+        metaEl.textContent = `${amount.toFixed(2)} PLN · ${scopeLabels[item.scope] || item.scope}`;
+
+        details.appendChild(nameEl);
+        details.appendChild(metaEl);
 
         const actions = document.createElement('div');
         actions.className = 'price-item-actions';

--- a/migrations/20240601_add_price_items_table.sql
+++ b/migrations/20240601_add_price_items_table.sql
@@ -1,0 +1,17 @@
+-- Migration: Add price_items table
+CREATE TABLE IF NOT EXISTS price_items (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    label VARCHAR(255) NOT NULL,
+    amount DECIMAL(10, 2) NOT NULL DEFAULT 0.00,
+    scope ENUM('all', 'adults') NOT NULL DEFAULT 'all'
+);
+
+INSERT INTO price_items (label, amount, scope)
+SELECT 'Upominek powitalny', 10.00, 'all'
+WHERE NOT EXISTS (SELECT 1 FROM price_items WHERE label = 'Upominek powitalny');
+
+INSERT INTO price_items (label, amount, scope)
+SELECT 'Toast dla dorosłych', 15.00, 'adults'
+WHERE NOT EXISTS (SELECT 1 FROM price_items WHERE label = 'Toast dla dorosłych');
+
+

--- a/sql_schema.sql
+++ b/sql_schema.sql
@@ -67,6 +67,14 @@ CREATE TABLE IF NOT EXISTS settings (
     setting_value TEXT
 );
 
+-- Tabela dla dodatkowych pozycji cenowych
+CREATE TABLE IF NOT EXISTS price_items (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    label VARCHAR(255) NOT NULL,
+    amount DECIMAL(10, 2) NOT NULL DEFAULT 0.00,
+    scope ENUM('all', 'adults') NOT NULL DEFAULT 'all'
+);
+
 -- Początkowe dane dla ustawień (POPRAWIONA SEKCJA)
 INSERT IGNORE INTO settings (setting_key, setting_value) VALUES
 ('wedding_date', ''),
@@ -74,3 +82,13 @@ INSERT IGNORE INTO settings (setting_key, setting_value) VALUES
 ('price_child_older', '0'),
 ('price_child_younger', '0'),
 ('price_accommodation', '0');
+
+-- Początkowe dane dla dodatkowych pozycji cenowych
+INSERT INTO price_items (label, amount, scope)
+SELECT 'Upominek powitalny', 10.00, 'all'
+WHERE NOT EXISTS (SELECT 1 FROM price_items WHERE label = 'Upominek powitalny');
+
+INSERT INTO price_items (label, amount, scope)
+SELECT 'Toast dla dorosłych', 15.00, 'adults'
+WHERE NOT EXISTS (SELECT 1 FROM price_items WHERE label = 'Toast dla dorosłych');
+


### PR DESCRIPTION
## Summary
- create the `price_items` table with seed data in the schema and provide a production migration
- implement PHP helpers and API plumbing to CRUD price items with validation
- extend the budget UI and client script to manage price items and incorporate them into totals

## Testing
- php -l functions.php
- php -l index.php
- php -l api_data.php

------
https://chatgpt.com/codex/tasks/task_e_68d84c5b18dc8323939f28905f5935ef